### PR TITLE
Jump to

### DIFF
--- a/fic-mode.el
+++ b/fic-mode.el
@@ -1,4 +1,4 @@
-;;; fic-mode.el --- Show FIXME/TODO/BUG(...) in special face only in comments and strings
+;;; fic-mode.el --- Show FIXME/TODO/BUG(...) in special face only in comments and strings ;; -*- lexical-binding: t -*-
 ;;--------------------------------------------------------------------
 ;;
 ;; Copyright (C) 2010, Trey Jackson <bigfaceworm(at)gmail(dot)com>
@@ -86,6 +86,9 @@
 (defvar fic-saved-regexp nil
   "Regexp cache for `fic-saved-hash'")
 
+(defvar fic-jump-buffer "*Fic-Jump*"
+  "The buffer jump from")
+
 (defun fic-search-re ()
   "Regexp to search for."
   (let ((hash (cons fic-highlighted-words fic-author-name-regexp)))
@@ -115,6 +118,88 @@
       (set-match-data match-data-to-set)
       (goto-char (match-end 0))
       t)))
+
+(defun fic--keyword-positions (&optional buffer limit)
+  "Return the LIMIT positions of keywords in BUFFER."
+  (with-current-buffer (or buffer (current-buffer))
+    (save-excursion
+      (save-match-data
+	(let (pos)
+	  (goto-char (point-min))
+	  (while (re-search-forward (fic-search-re) limit t)
+	    (pcase (match-data)
+	      (`(,s ,e . ,_)
+	       (when (eq (get-char-property s 'face) 'fic-face)
+		 (add-to-list 'pos e)))))
+	  (reverse pos))))))
+
+(defun fic--content-in-line-in-position (marker)
+  "Return the content in line in location MARKER."
+  (let ((frombuf (marker-buffer marker))
+	(pos (marker-position marker)))
+    (if (not (buffer-live-p frombuf))
+	(message "Buffer %s is not alive"  (buffer-name frombuf))
+      (with-current-buffer frombuf
+	(goto-line (line-number-at-pos pos))
+	(buffer-substring (line-beginning-position) (line-end-position))))))
+
+(defun fic--lineno-in-position (marker)
+  "Return line number in MARKER."
+  (let ((buf (marker-buffer marker))
+	(pos (marker-position marker)))
+    (if (not (buffer-live-p buf))
+	(message "Buffer %s is not alive" (buffer-name frombuf))
+      (with-current-buffer buf
+	(line-number-at-pos pos)))))
+
+(defun fic--jump-to (marker)
+  "Jump to the MARKER."
+  (let ((tobuf (marker-buffer marker))
+	(pos (marker-position marker)))
+    (if (not (buffer-live-p tobuf))
+	(message "Buffer %s is not alive" (buffer-name tobuf))
+      (progn
+	(switch-to-buffer tobuf)
+	(goto-char pos)))))
+
+
+(defun fic--append-line-to-buffer (&optional buffer)
+  "Append the lines where keywords located in to BUFFER.
+By default, BUFFER is named \"*Fic-Jump*\"."
+  (let* ((oldbuf (current-buffer))
+	 (newbuf (get-buffer-create (or buffer fic-jump-buffer)))
+	 (markers (fic--keyword-positions oldbuf)))
+    (if (with-current-buffer oldbuf
+	  (bound-and-true-p fic-mode))
+	(progn
+	  (with-current-buffer newbuf
+	    (let ((inhibit-read-only t))
+	      (dolist (marker markers)
+		(let ((beg (point)))
+		  (insert (format "Buffer: %s  "(buffer-name (marker-buffer marker))))
+		  (insert (format "Line: %s " (fic--lineno-in-position marker)))
+		  (insert (format "%s ..." (fic--content-in-line-in-position marker)))
+		  (make-button
+		   beg (point) 'action
+		   ((lambda (mkr) (lambda (x) (fic--jump-to mkr)))
+		    marker)))
+		(insert "\n"))))
+	  (view-buffer (get-buffer newbuf)))
+      (message "The fic-mode is disabled in this buffer."))))
+
+(defun fic-jump (&optional buffer)
+  "Jump to where keyword located in.
+BUFFER is the buffer to list the lines where keywords located in."
+  (interactive)
+  (let ((bufs (buffer-list))
+	(buffer (get-buffer-create (or buffer fic-jump-buffer))))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+	(erase-buffer)))
+    (dolist (buf bufs)
+      (with-current-buffer buf
+	(when fic-mode
+	  (fic--append-line-to-buffer buffer))))))
 
 ;;;###autoload
 (define-minor-mode fic-mode

--- a/fic-mode.el
+++ b/fic-mode.el
@@ -174,17 +174,22 @@ By default, BUFFER is named \"*Fic-Jump*\"."
 	  (with-current-buffer newbuf
 	    (let ((inhibit-read-only t))
 	      (dolist (marker markers)
-		(insert (format "Buffer: %s  "(buffer-name (marker-buffer marker))))
-		(insert (format "Line: %s " (fic--lineno-in-position marker)))
-		(insert (format "%s " (fic--content-in-line-in-position marker)))
 		(let ((beg (point)))
-		  (insert (format "..." (fic--content-in-line-in-position marker)))
+		  (insert (format "Visit" (fic--content-in-line-in-position marker)))
 		  (make-text-button
 		   beg (point)
 		   'follow-link t
+;;		   'face '(:underline nil)
 		   'mouse-face 'highlight
 		   'help-echo "Click to visit it in other window"
-		   'action ((lambda (mkr) (lambda (x) (fic--jump-to mkr))) marker)))
+		   'action ((lambda (mkr)
+			      (lambda (x)
+				(let ((inhibit-read-only t)) (erase-buffer))
+				(fic--jump-to mkr))) marker)))
+		(insert " ")
+		(insert (format "Buffer: %s  "(buffer-name (marker-buffer marker))))
+		(insert (format "Line: %s " (fic--lineno-in-position marker)))
+		(insert (format "%s " (fic--content-in-line-in-position marker)))
 		(insert "\n"))))
 	  (view-buffer (get-buffer newbuf)))
       (message "The fic-mode is disabled in this buffer."))))

--- a/fic-mode.el
+++ b/fic-mode.el
@@ -77,8 +77,8 @@
   :group 'fic-mode)
 
 (defvar fic-mode-font-lock-keywords '((fic-search-for-keyword
-                                       (1 'fic-face t)
-                                       (2 'fic-author-face t t))) 
+				       (1 'fic-face t)
+				       (2 'fic-author-face t t)))
   "Font Lock keywords for fic-mode")
 
 (defvar fic-saved-hash nil
@@ -93,18 +93,18 @@
   "Regexp to search for."
   (let ((hash (cons fic-highlighted-words fic-author-name-regexp)))
     (if (and fic-saved-hash
-           (equal fic-saved-hash hash))
-        fic-saved-regexp
+	   (equal fic-saved-hash hash))
+	fic-saved-regexp
       (let ((fic-words-re (concat "\\<"
-                                  (regexp-opt fic-highlighted-words t)
-                                  "\\>")))
-        (setq fic-saved-hash hash
-              fic-saved-regexp (concat fic-words-re "\\(?:(\\(" fic-author-name-regexp "\\))\\)?"))
-        fic-saved-regexp))))
+				  (regexp-opt fic-highlighted-words t)
+				  "\\>")))
+	(setq fic-saved-hash hash
+	      fic-saved-regexp (concat fic-words-re "\\(?:(\\(" fic-author-name-regexp "\\))\\)?"))
+	fic-saved-regexp))))
 
 (defun fic-in-doc/comment-region (pos)
   (memq (get-char-property pos 'face)
-        fic-activated-faces))
+	fic-activated-faces))
 
 (defun fic-search-for-keyword (limit)
   (let (match-data-to-set)
@@ -162,7 +162,6 @@
 	(switch-to-buffer tobuf)
 	(goto-char pos)))))
 
-
 (defun fic--append-line-to-buffer (&optional buffer)
   "Append the lines where keywords located in to BUFFER.
 By default, BUFFER is named \"*Fic-Jump*\"."
@@ -175,14 +174,17 @@ By default, BUFFER is named \"*Fic-Jump*\"."
 	  (with-current-buffer newbuf
 	    (let ((inhibit-read-only t))
 	      (dolist (marker markers)
+		(insert (format "Buffer: %s  "(buffer-name (marker-buffer marker))))
+		(insert (format "Line: %s " (fic--lineno-in-position marker)))
+		(insert (format "%s " (fic--content-in-line-in-position marker)))
 		(let ((beg (point)))
-		  (insert (format "Buffer: %s  "(buffer-name (marker-buffer marker))))
-		  (insert (format "Line: %s " (fic--lineno-in-position marker)))
-		  (insert (format "%s ..." (fic--content-in-line-in-position marker)))
-		  (make-button
-		   beg (point) 'action
-		   ((lambda (mkr) (lambda (x) (fic--jump-to mkr)))
-		    marker)))
+		  (insert (format "..." (fic--content-in-line-in-position marker)))
+		  (make-text-button
+		   beg (point)
+		   'follow-link t
+		   'mouse-face 'highlight
+		   'help-echo "Click to visit it in other window"
+		   'action ((lambda (mkr) (lambda (x) (fic--jump-to mkr))) marker)))
 		(insert "\n"))))
 	  (view-buffer (get-buffer newbuf)))
       (message "The fic-mode is disabled in this buffer."))))


### PR DESCRIPTION
Add a interactive function named fic-jump, which will capture the lines where keywords located in from all buffers which have enabled the fic-mode, into *Fic-Jump* buffer. Users can click the head of line to jump to where keywords located in.

The thing needs to be enhanced is the text format of *Fic-Jump*, which is "ugly".